### PR TITLE
fix: disable ssr for labels to avoid hydration error

### DIFF
--- a/components/table/table.tsx
+++ b/components/table/table.tsx
@@ -11,9 +11,14 @@ import {
 } from "@nextui-org/table";
 import { Spinner } from "@nextui-org/spinner";
 import { Contribution, PaginatedContributions } from "@/types/contribution";
-import { ExternalLink, Content, Labels, Time, Project } from "./row";
+import { ExternalLink, Content, Time, Project } from "./row";
+
 import { useContributions } from "@/hooks/useContributions";
 import { KudosQueryParameters } from "@/lib/notion/types";
+import dynamic from "next/dynamic";
+const Labels = dynamic(() => import("./row").then((m) => m.Labels), {
+  ssr: false,
+});
 
 interface IColumn {
   name: string;


### PR DESCRIPTION
Suggested fix for hydration errors related to the randomisation of the labels. Let me know what you think.

<img width="1433" alt="Screenshot 2024-01-19 at 10 36 03" src="https://github.com/kudos-ink/portal/assets/48095175/a762ae4a-a0d1-4746-9b6d-6f8843e72342">
