### PR TITLE
[Feat] cache's revalidate endpoint

### DIFF
--- a/app/api/revalidate/[tag]/route.ts
+++ b/app/api/revalidate/[tag]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { getTags } from "@/utils/cache";
+
+export async function POST(
+  _: NextRequest,
+  { params }: { params: { tag: string } },
+) {
+  const tag = params.tag;
+
+  if (!getTags().includes(tag)) {
+    return NextResponse.json({ error: "Invalid tag" }, { status: 400 });
+  }
+  revalidateTag(tag);
+
+  return NextResponse.json({ revalidated: tag });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import { unstable_noStore } from "next/cache";
 import ControlledTable from "@/components/controlled-table";
 import { DEFAULT_PAGE_SIZE } from "@/data/fetch";
 import { queryDatabase } from "@/lib/notion";
@@ -9,7 +8,6 @@ import { initFilters } from "@/utils/filters";
 import { transformNotionDataToContributions } from "@/utils/notion";
 
 export default async function Home() {
-  unstable_noStore();
   const filterOptions = await fetchFilterOptions();
   const filters = initFilters();
   const data = await queryDatabase({

--- a/lib/notion/index.ts
+++ b/lib/notion/index.ts
@@ -15,6 +15,12 @@ import { KudosQueryParameters } from "./types";
 
 const notion = new Client({
   auth: process.env.NOTION_API_KEY,
+  fetch: (url, opts) => {
+    return fetch(url, {
+      ...opts,
+      next: { revalidate: +process.env.NOTION_CACHE_DURATION! },
+    });
+  },
 });
 
 export async function baseQueryDatabase(

--- a/lib/repository-metadata/index.ts
+++ b/lib/repository-metadata/index.ts
@@ -1,10 +1,11 @@
 import { FilterOption, FilterOptions } from "@/types/filters";
+import { FILTER_TAGS } from "@/utils/cache";
 
 const REPOSITORY_CLASSIFICATION_URL = process.env.REPOSITORY_CLASSIFICATION_URL;
 
 async function fetchData(url: string): Promise<FilterOption[]> {
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, { next: { tags: [FILTER_TAGS] } });
 
     if (!response.ok) {
       throw new Error(`Failed to fetch data. Status: ${response.status}`);
@@ -35,7 +36,9 @@ export async function fetchFilterOptions(): Promise<FilterOptions> {
     // We want repositories with the id used in Notion.
     // If they don't have it means they aren't loaded in the
     // Notion table yet
-    const repositories = allRepositories.filter((value) => value.id && value.id !== "");
+    const repositories = allRepositories.filter(
+      (value) => value.id && value.id !== "",
+    );
     return { interests, languages, repositories };
   } catch (error) {
     console.error("Error fetching filter options:", error);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const [AUTH_USER, AUTH_PASS] = (process.env.HTTP_BASIC_AUTH || ":").split(":");
+
+export function middleware(req: NextRequest) {
+  if (!isAuthenticated(req)) {
+    return new NextResponse("Authentication required", {
+      status: 401,
+      headers: { "WWW-Authenticate": "Basic" },
+    });
+  }
+
+  return NextResponse.next();
+}
+
+function isAuthenticated(req: NextRequest) {
+  const authheader =
+    req.headers.get("authorization") || req.headers.get("Authorization");
+
+  if (!authheader) {
+    return false;
+  }
+  const auth = Buffer.from(authheader.split(" ")[1], "base64")
+    .toString()
+    .split(":");
+  console.log(auth);
+
+  const user = auth[0];
+  const pass = auth[1];
+
+  if (user == AUTH_USER && pass == AUTH_PASS) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+export const config = {
+  matcher: "/api/revalidate/:path*",
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,7 +24,6 @@ function isAuthenticated(req: NextRequest) {
   const auth = Buffer.from(authheader.split(" ")[1], "base64")
     .toString()
     .split(":");
-  console.log(auth);
 
   const user = auth[0];
   const pass = auth[1];

--- a/utils/cache.ts
+++ b/utils/cache.ts
@@ -1,0 +1,5 @@
+export const FILTER_TAGS = "filter-options";
+
+export function getTags() {
+  return [FILTER_TAGS];
+}


### PR DESCRIPTION
- Revalidate endpoint (protected with Basic Auth)
- filter's fetch has cache tag so it can be revalidated
- Basic auth middleware
- Time-based cache for notion calls (NOTION_CACHE_DURATION)

Before merging we need to create these env vars NOTION_CACHE_DURATION and HTTP_BASIC_AUTH in Vercel
