### PR TITLE
Update page.tsx

### DIFF
--- a/app/carnival/page.tsx
+++ b/app/carnival/page.tsx
@@ -147,7 +147,7 @@ export default async function SingleEventPage() {
   });
 
   const query: IssueQueryParams = {
-    kudos: true,
+    certified: true,
     open: true,
   };
   const issues = (await IssuesApi.getIssues({


### PR DESCRIPTION
Filter by `certified` instead of `kudos` to account for manual certification. All `kudos` labelled issues are certified but not all `certified` issues are labelled `kudos`.