### PR TITLE
[feat] Add `certified_or_labels` in `/issues`

### DIFF
--- a/api/core/_transformers.ts
+++ b/api/core/_transformers.ts
@@ -76,5 +76,6 @@ export function issueQueryParamsToDto(
     language_slugs: languageSlugs.length > 0 ? languageSlugs : undefined,
     offset: query.offset,
     limit: query.limit,
+    certified_or_labels: combinedLabels.length > 0 && query.certified,
   };
 }

--- a/types/issue.ts
+++ b/types/issue.ts
@@ -61,5 +61,6 @@ export type IssueQueryParamsDto = Partial<{
   has_assignee: boolean;
   issue_closed_at_min: string;
   issue_closed_at_max: string;
+  certified_or_labels: boolean;
 }> &
   Partial<PaginationQueryParams>;


### PR DESCRIPTION
- Add new query argument to get certified OR issues with labels in carnival page.  